### PR TITLE
Pass requested OAuth scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "linear",
   "author": "Linear Orbit, Inc",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "icon": "assets/128x128.png",
   "repository": {
     "type": "git",

--- a/src/LinearAuthenticationProvider.ts
+++ b/src/LinearAuthenticationProvider.ts
@@ -71,7 +71,7 @@ export class LinearAuthenticationProvider
       return existingSession;
     }
 
-    const token = await this.login();
+    const token = await this.login(scopes);
     if (!token) {
       vscode.window.showErrorMessage(
         "There was a problem trying to authenticate with Linear!"
@@ -152,14 +152,14 @@ export class LinearAuthenticationProvider
 
   // -- Private interface
 
-  private async login(): Promise<string> {
+  private async login(scopes: string[]): Promise<string> {
     const state = uuid();
 
     const searchParams = new URLSearchParams([
       ["client_id", OAUTH_CLIENT_ID],
       ["redirect_uri", OAUTH_REDIRECT_URL],
       ["response_type", "code"],
-      ["scope", "read"],
+      ["scope", scopes],
       ["state", state],
       ["prompt", "consent"],
     ]);


### PR DESCRIPTION
I think by mistake "read" was hardcoded in there. So even if you tried to request other scopes you'd only be allowed read access.