### PR TITLE
Pass scopes correctly to OAuth authorize window

### DIFF
--- a/src/LinearAuthenticationProvider.ts
+++ b/src/LinearAuthenticationProvider.ts
@@ -159,7 +159,7 @@ export class LinearAuthenticationProvider
       ["client_id", OAUTH_CLIENT_ID],
       ["redirect_uri", OAUTH_REDIRECT_URL],
       ["response_type", "code"],
-      ["scope", scopes],
+      ["scope", scopes.join(",")],
       ["state", state],
       ["prompt", "consent"],
     ]);


### PR DESCRIPTION
Noticed in another extension that uses this one that passing `["read", "write"]` as scopes still results in the token getting created with only `read` permissions. I think this will fix it since we need a comma-separated string of scopes to be passed: https://developers.linear.app/docs/oauth/authentication#2.-redirect-user-access-requests-to-linear